### PR TITLE
Fix unstable library name by workspace-state.json

### DIFF
--- a/Sources/SourcePackagesParser/SourcePackagesParser.swift
+++ b/Sources/SourcePackagesParser/SourcePackagesParser.swift
@@ -37,7 +37,7 @@ final class SourcePackagesParser {
                 return nil
             }
             return Library(
-                name: dependency.packageRef.name,
+                name: repositoryName,
                 url: dependency.packageRef.location,
                 licenseBody: licenseBody
             )


### PR DESCRIPTION
LicenseListはSwiftPackageManagerが生成するworkspace-state.jsonから名前を取得しているが、
このworkspace-state.jsonのnameは名前が不安定で"ocmock"だったり"OCMock"だったりする。

不安定なのを解消するためにリポジトリ名を取ることで統一することにする。